### PR TITLE
add api-path

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -30,10 +30,11 @@ class CwrCIProvides(RelationBase):
         conv = self.conversation()
         conv.remove_state('{relation_name}.joined')
 
-    def set_ready(self, port, controllers):
+    def set_ready(self, port, api_path, controllers):
         self.set_remote(data={
             'ready': True,
             'port': port,
+            'api-path': api_path,
             'controllers': json.dumps(sorted(controllers)),
         })
 

--- a/requires.py
+++ b/requires.py
@@ -44,5 +44,7 @@ class CwrCIRequires(RelationBase):
         conv = self.conversation()
         ip = conv.get_remote('private-address')
         port = conv.get_remote('port')
+        api_path = conv.get_remote('api-path')
         controllers = json.loads(conv.get_remote('controllers', []))
-        return {"ip": ip, "port": port, "controllers": controllers}
+        return {"ip": ip, "port": port, "api_path": api_path,
+                "controllers": controllers}


### PR DESCRIPTION
Clients need to know the api-path (which might change in the future) so they can construct the right url for sending rest requests.